### PR TITLE
Send slider state from JS to Shiny on play / replay

### DIFF
--- a/sandbox/app/scripts/app.js
+++ b/sandbox/app/scripts/app.js
@@ -134,6 +134,10 @@ function play(id) {
   const tick = () => {
     animateFrame(frameIndex, id);
     frameIndex++;
+    if(HTMLWidgets.shinyMode){
+      var prevIndex = frameIndex - 1;
+      Shiny.onInputChange("slider_state", prevIndex);
+    }
   };
   tick();
 


### PR DESCRIPTION
Added a line into the play() function that sends the status of the slider so that its position can update the tabs (as mentioned in #45)


https://user-images.githubusercontent.com/15895337/121203963-8636c600-c844-11eb-8b9b-bfe1e1eab40e.mov

