### PR TITLE
Extract plot mapping from geom_point() layer

### DIFF
--- a/R/generate_mapping_from_plot.R
+++ b/R/generate_mapping_from_plot.R
@@ -3,6 +3,12 @@ generate_mapping_from_plot <- function(plot) {
   x <- plot$mapping$x %>%
     rlang::quo_name()
 
+  # If there is no plot mapping, the mapping was done in the geom, so grab from there instead
+  if (x == "NULL" & "GeomPoint" %in% class(plot$layers[[1]]$geom)) {
+    x <- plot$layers[[1]]$mapping$x %>%
+      rlang::quo_name()
+  }
+
   #  Need to get y variable from the pipeline, since we want the "original" variable, not the transformed one that appears on the plot
 
   plot_mapping <- list(x = x)

--- a/tests/testthat/test-generate_mapping_from_plot.R
+++ b/tests/testthat/test-generate_mapping_from_plot.R
@@ -1,0 +1,33 @@
+test_that("generate_mapping_from_plot can extract x mapping from ggplot", {
+  p <- ggplot2::ggplot(mtcars, ggplot2::aes(x = mpg, y = cyl)) +
+    ggplot2::geom_point()
+  mapping <- generate_mapping_from_plot(p)
+  expect_identical(mapping, list(x = "mpg"))
+  })
+
+test_that("generate_mapping_from_plot can extract x mapping from geo_point", {
+  p <- ggplot2::ggplot(mtcars) +
+    ggplot2::geom_point(ggplot2::aes(x = mpg, y = cyl))
+  mapping <- generate_mapping_from_plot(p)
+  expect_identical(mapping, list(x = "mpg"))
+})
+
+test_that("generate_mapping_from_plot extracts facets", {
+  p <- ggplot2::ggplot(mtcars) +
+    ggplot2::geom_point(ggplot2::aes(x = mpg, y = cyl)) +
+    ggplot2::facet_grid(dplyr::vars(vs), dplyr::vars(am))
+  mapping <- generate_mapping_from_plot(p)
+  expect_identical(mapping, list(x = "mpg", row = "vs", column = "am"))
+
+  p <- ggplot2::ggplot(mtcars) +
+    ggplot2::geom_point(ggplot2::aes(x = mpg, y = cyl)) +
+    ggplot2::facet_grid(dplyr::vars(vs))
+  mapping <- generate_mapping_from_plot(p)
+  expect_identical(mapping, list(x = "mpg", row = "vs"))
+
+  p <- ggplot2::ggplot(mtcars) +
+    ggplot2::geom_point(ggplot2::aes(x = mpg, y = cyl)) +
+    ggplot2::facet_grid(am~vs)
+  mapping <- generate_mapping_from_plot(p)
+  expect_identical(mapping, list(x = "mpg", row = "am", column = "vs"))
+})


### PR DESCRIPTION
Trying out smaller PRs to knock off some issues!

Closes #72, extracts plot mapping from the `geom_point()` layer if it's not defined in the actual `ggplot()` call itself.