### PR TITLE
Check for HTMLWidgets before checking for Shiny to send slider info

### DIFF
--- a/inst/htmlwidgets/js/app.js
+++ b/inst/htmlwidgets/js/app.js
@@ -134,7 +134,7 @@ function play(id) {
   const tick = () => {
     animateFrame(frameIndex, id);
     frameIndex++;
-    if(HTMLWidgets.shinyMode){
+    if(typeof HTMLWidgets !== "undefined" && HTMLWidgets.shinyMode){
       var prevIndex = frameIndex - 1;
       Shiny.onInputChange("slider_state", prevIndex);
     }


### PR DESCRIPTION
Closing out #56, this adds the fix that @giorgi-ghviniashvili mentioned in #70 where the code needs to first check that HTMLWidgets is defined before it can also check that Shiny is defined - HTMLWidgets is always defined when we call the widget in R, since it's created through the HTMLWidgets framework, but it may not be defined when calling the JS code without R, or with other languages, etc, so needs to be checked for :)