### PR TITLE
Fix R Cmd Check erroring

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@ azure-pipelines.yml
 ^_pkgdown\.yml$
 ^R/README\.md$
 ^LICENSE\.md$
+^R/app_server\.R$


### PR DESCRIPTION
The r cmd check / continuous integration is failing because of an issue where packages are loaded directly, e.g. library(dplyr). You're not supposed to do this in an R package, but it's only happening in the Shiny app - so for now I'm excluding the offending file from the check. This will be solved more fully as part of #71, since we won't run these same checks on the Shiny app on its own.