### PR TITLE
Fix bug where datamating data with x/y column names didn't work

### DIFF
--- a/R/prep_specs_data.R
+++ b/R/prep_specs_data.R
@@ -11,8 +11,8 @@ prep_specs_data <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, height
   specs_list <- vector("list", length = 1)
 
   # Prep encoding
-  x_encoding <- list(field = "x", type = "quantitative", axis = NULL)
-  y_encoding <- list(field = "y", type = "quantitative", axis = NULL)
+  x_encoding <- list(field = X_FIELD_CHR, type = "quantitative", axis = NULL)
+  y_encoding <- list(field = Y_FIELD_CHR, type = "quantitative", axis = NULL)
 
   spec_encoding <- list(x = x_encoding, y = y_encoding)
 

--- a/R/prep_specs_group_by.R
+++ b/R/prep_specs_group_by.R
@@ -25,8 +25,8 @@ prep_specs_group_by <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, he
 
   # Prep encoding ----
 
-  x_encoding <- list(field = "x", type = "quantitative", axis = NULL)
-  y_encoding <- list(field = "y", type = "quantitative", axis = NULL)
+  x_encoding <- list(field = X_FIELD_CHR, type = "quantitative", axis = NULL)
+  y_encoding <- list(field = Y_FIELD_CHR, type = "quantitative", axis = NULL)
   color_encoding <- list(field = rlang::quo_name(mapping$color), type = "nominal")
 
   # Need to manually set order of colour legend, otherwise it's not in the same order as the grids/points!

--- a/R/prep_specs_summarize.R
+++ b/R/prep_specs_summarize.R
@@ -173,7 +173,7 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
   if (mapping$summary_function == "mean") {
     data_3 <- data_1 %>%
       # The errorbar is calculated by vega so we need to send the raw y values, and the summarised ones
-      dplyr::mutate(.y_raw = !!Y_FIELD) %>%
+      dplyr::mutate(!!Y_RAW_FIELD := !!Y_FIELD) %>%
       dplyr::group_by(!!!group_vars) %>%
       dplyr::mutate(dplyr::across(!!Y_FIELD, !!summary_function, na.rm = TRUE))
 
@@ -203,11 +203,10 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
     description <- glue::glue("{description}, with errorbar, zoomed in")
 
     # Calculating errorbar (CI? Not actually the same as what vegalite calculates?) so that we can set the range for the zoom
-    browser()
     data_errorbar <- data_3 %>%
       dplyr::summarize(
         !!Y_FIELD := !!Y_FIELD,
-        sd = stats::sd(.data$.y_raw, na.rm = TRUE),
+        sd = stats::sd(!!Y_RAW_FIELD, na.rm = TRUE),
         n = n()
       ) %>%
       dplyr::distinct() %>%

--- a/R/prep_specs_summarize.R
+++ b/R/prep_specs_summarize.R
@@ -33,7 +33,7 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
     # Add an ID used internally by our JS code / by gemini that controls how points are animated between frames
     # Not defined in any of the previous steps since the JS takes care of generating it
     dplyr::mutate(gemini_id = dplyr::row_number()) %>%
-    dplyr::rename(y = {{ summary_variable }})
+    dplyr::rename(!!Y_FIELD := {{ summary_variable }})
 
   # Add an x variable to use as the center of jittering
   # It can just be 1, except if mapping$x is not 1!
@@ -41,7 +41,7 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
 
   if (mapping$x == 1) {
     .data <- .data %>%
-      dplyr::mutate(x = 1)
+      dplyr::mutate(!!X_FIELD := 1)
 
     x_labels <- generate_labelsExpr(NULL)
     x_domain <- generate_x_domain(NULL)
@@ -51,17 +51,17 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
 
     .data <- .data %>%
       dplyr::mutate(
-        x = as.numeric({{ x_var }})
+        !!X_FIELD := as.numeric({{ x_var }})
       )
 
     x_labels <- .data %>%
       dplyr::ungroup() %>%
-      dplyr::distinct(.data$x, label = {{ x_var }}) %>%
+      dplyr::distinct(!!X_FIELD, label = {{ x_var }}) %>%
       generate_labelsExpr()
 
     x_domain <- .data %>%
       dplyr::ungroup() %>%
-      dplyr::distinct(.data$x, label = {{ x_var }}) %>%
+      dplyr::distinct(!!X_FIELD, label = {{ x_var }}) %>%
       generate_x_domain()
 
     x_title <- mapping$x
@@ -69,10 +69,10 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
 
   # Prep encoding ----
 
-  x_encoding <- list(field = "x", type = "quantitative", axis = list(values = x_labels[["breaks"]], labelExpr = x_labels[["labelExpr"]], labelAngle = -90), title = x_title, scale = x_domain)
+  x_encoding <- list(field = X_FIELD_CHR, type = "quantitative", axis = list(values = x_labels[["breaks"]], labelExpr = x_labels[["labelExpr"]], labelAngle = -90), title = x_title, scale = x_domain)
 
-  y_range <- range(.data[["y"]], na.rm = TRUE)
-  y_encoding <- list(field = "y", type = "quantitative", title = mapping$y, scale = list(domain = y_range))
+  y_range <- range(.data[[Y_FIELD_CHR]], na.rm = TRUE)
+  y_encoding <- list(field = Y_FIELD_CHR, type = "quantitative", title = mapping$y, scale = list(domain = y_range))
 
   color_encoding <- list(field = rlang::quo_name(mapping$color), type = "nominal")
 
@@ -108,11 +108,11 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
   # State 1: Scatter plot (with any grouping) -----
 
   data_1 <- .data %>%
-    dplyr::select(.data$gemini_id, tidyselect::any_of(group_vars_chr), .data$x, .data$y)
+    dplyr::select(.data$gemini_id, tidyselect::any_of(group_vars_chr), !!X_FIELD, !!Y_FIELD)
 
   # Remove NA values, since their values will not be displayed - better to have them fade off
   data_1 <- data_1 %>%
-    dplyr::filter(!is.na(.data$y))
+    dplyr::filter(!is.na(!!Y_FIELD))
 
   # Generate description
   description <- generate_summarize_description(summary_variable, group_by = length(group_vars) != 0)
@@ -148,7 +148,7 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
 
   data_2 <- data_1 %>%
     dplyr::group_by(!!!group_vars) %>%
-    dplyr::mutate(dplyr::across(.data$y, !!summary_function, na.rm = TRUE))
+    dplyr::mutate(dplyr::across(!!Y_FIELD, !!summary_function, na.rm = TRUE))
 
   # Generate description
   description <- generate_summarize_description(summary_variable, summary_function, group_by = length(group_vars) != 0)
@@ -173,9 +173,9 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
   if (mapping$summary_function == "mean") {
     data_3 <- data_1 %>%
       # The errorbar is calculated by vega so we need to send the raw y values, and the summarised ones
-      dplyr::mutate(y_raw = .data$y) %>%
+      dplyr::mutate(.y_raw = !!Y_FIELD) %>%
       dplyr::group_by(!!!group_vars) %>%
-      dplyr::mutate(dplyr::across(.data$y, !!summary_function, na.rm = TRUE))
+      dplyr::mutate(dplyr::across(!!Y_FIELD, !!summary_function, na.rm = TRUE))
 
     description <- generate_summarize_description(summary_variable, summary_function, errorbar = TRUE, group_by = length(group_vars) != 0)
 
@@ -203,17 +203,18 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
     description <- glue::glue("{description}, with errorbar, zoomed in")
 
     # Calculating errorbar (CI? Not actually the same as what vegalite calculates?) so that we can set the range for the zoom
+    browser()
     data_errorbar <- data_3 %>%
       dplyr::summarize(
-        y = .data$y,
-        sd = stats::sd(.data$y_raw, na.rm = TRUE),
+        !!Y_FIELD := !!Y_FIELD,
+        sd = stats::sd(.data$.y_raw, na.rm = TRUE),
         n = n()
       ) %>%
       dplyr::distinct() %>%
       dplyr::mutate(
         se = 1.96 * .data$sd / sqrt(.data$n),
-        lcl = .data$y - .data$se,
-        ucl = .data$y + .data$se
+        lcl = !!Y_FIELD - .data$se,
+        ucl = !!Y_FIELD + .data$se
       )
 
     lcl <- min(data_errorbar[["lcl"]], na.rm = TRUE)
@@ -235,7 +236,7 @@ prep_specs_summarize <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, h
     description <- glue::glue("{description}, zoomed in")
 
     # Range is just the range of the actual y
-    range_y <- range(data_2[["y"]], na.rm = TRUE)
+    range_y <- range(data_2[[Y_FIELD_CHR]], na.rm = TRUE)
     spec_encoding$y$scale$domain <- range_y
 
     spec <- generate_vega_specs(

--- a/R/prep_specs_utils.R
+++ b/R/prep_specs_utils.R
@@ -37,7 +37,7 @@ generate_unfacet_vega_specs <- function(.data, meta, spec_encoding, height, widt
 
     # The errorbar has its own encoding, and it uses data y_raw (the actual raw values) to calculate the errorbar
     errorbar_spec_encoding <- spec_encoding
-    errorbar_spec_encoding$y$field <- "y_raw"
+    errorbar_spec_encoding$y$field <- Y_RAW_FIELD_CHR
 
     list(
       height = height,
@@ -106,7 +106,7 @@ generate_facet_vega_specs <- function(.data, mapping, meta, spec_encoding, facet
 
     # The errorbar has its own encoding, and it uses data y_raw (the actual raw values) to calculate the errorbar
     errorbar_spec_encoding <- spec_encoding
-    errorbar_spec_encoding$y$field <- "y_raw"
+    errorbar_spec_encoding$y$field <- Y_RAW_FIELD_CHR
 
     list(
       `$schema` = vegawidget::vega_schema(),

--- a/R/prep_specs_utils.R
+++ b/R/prep_specs_utils.R
@@ -221,7 +221,7 @@ generate_labelsExpr <- function(data) {
     dplyr::mutate(label = dplyr::coalesce(.data$label, "undefined"))
 
   n_breaks <- nrow(data)
-  breaks <- data[["x"]]
+  breaks <- data[[X_FIELD_CHR]]
   labels <- data[["label"]]
 
   labelExpr <- c(glue::glue("round(datum.label) == {ceiling(breaks[1:(n_breaks - 1)])} ? '{labels[1:(n_breaks - 1)]}'"), glue::glue("'{labels[n_breaks]}'")) %>% paste0(collapse = " : ")
@@ -236,7 +236,7 @@ generate_x_domain <- function(data) {
   if (is.null(data)) {
     list(domain = c(0.5, 1.5))
   } else {
-    list(domain = c(min(data[["x"]]) - 0.5, max(data[["x"]]) + 0.5))
+    list(domain = c(min(data[[X_FIELD_CHR]]) - 0.5, max(data[[X_FIELD_CHR]]) + 0.5))
   }
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,5 @@
+X_FIELD_CHR <- "datamations_x"
+X_FIELD <- rlang::sym(X_FIELD_CHR)
+Y_FIELD_CHR <- "datamations_y"
+Y_FIELD <- rlang::sym(Y_FIELD_CHR)
+SCHEME <- "https://vega.github.io/schema/vega-lite/v4.json"

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,4 +2,5 @@ X_FIELD_CHR <- "datamations_x"
 X_FIELD <- rlang::sym(X_FIELD_CHR)
 Y_FIELD_CHR <- "datamations_y"
 Y_FIELD <- rlang::sym(Y_FIELD_CHR)
-SCHEME <- "https://vega.github.io/schema/vega-lite/v4.json"
+Y_RAW_FIELD_CHR <- "datamations_y_raw"
+Y_RAW_FIELD <- rlang::sym(Y_RAW_FIELD_CHR)

--- a/inst/htmlwidgets/datamationSandDance.yaml
+++ b/inst/htmlwidgets/datamationSandDance.yaml
@@ -19,6 +19,10 @@ dependencies:
    version: 0.1.0
    src: htmlwidgets/gemini
    script: gemini.web.js
+ - name: config
+   version: 0.0.1
+   src: htmlwidgets/js
+   script: config.js
  - name: utils
    version: 0.0.1
    src: htmlwidgets/js

--- a/inst/htmlwidgets/js/config.js
+++ b/inst/htmlwidgets/js/config.js
@@ -1,0 +1,5 @@
+const CONF = {
+  X_FIELD: "datamations_x",
+  Y_FIELD: "datamations_y",
+  SCHEME: "https://vega.github.io/schema/vega-lite/v4.json"
+};

--- a/inst/htmlwidgets/js/hack-facet-view.js
+++ b/inst/htmlwidgets/js/hack-facet-view.js
@@ -1,11 +1,3 @@
-/**
- * Creates vega-lite spec template
- * @param {Number} width chart width
- * @param {Number} height chart height
- * @param {Object} axes which axis to include
- * @param {Object} spec vega-lite spec
- * @returns vega-lite spec template
- */
 function getSpecTemplate(width, height, axes = { x: true, y: true }, spec) {
   const encoding = spec.spec.encoding;
   const mark = spec.spec.mark;
@@ -15,7 +7,7 @@ function getSpecTemplate(width, height, axes = { x: true, y: true }, spec) {
     const title = facet && facet.column ? facet.column.title : null;
 
     encoding.x = {
-      field: "x",
+      field: CONF.X_FIELD,
       type: "quantitative",
       scale: {},
       axis: axes.x ? {
@@ -35,7 +27,7 @@ function getSpecTemplate(width, height, axes = { x: true, y: true }, spec) {
     const title = facet && facet.row ? facet.row.title : null;
 
     encoding.y = {
-      field: spec.spec.mark === "errorbar" ? encoding.y.field : "y",
+      field: spec.spec.mark === "errorbar" ? encoding.y.field : CONF.Y_FIELD,
       type: "quantitative",
       scale: {},
       axis: axes.y ? {
@@ -53,7 +45,7 @@ function getSpecTemplate(width, height, axes = { x: true, y: true }, spec) {
   }
 
   return {
-    $schema: "https://vega.github.io/schema/vega-lite/v4.json",
+    $schema: CONF.SCHEME,
     data: {
       values: [],
     },
@@ -64,11 +56,6 @@ function getSpecTemplate(width, height, axes = { x: true, y: true }, spec) {
   };
 }
 
-/**
- * Creates a vega-lite specification, without facets
- * @param {Object} param0 some parameters to generate hacked specification
- * @returns new vega-lite specification
- */
 function getHackedSpec({ view, spec, width = 600, height = 600 }) {
   const rowId = spec.facet.row ? spec.facet.row.field : null;
   const colId = spec.facet.column ? spec.facet.column.field : null;
@@ -154,10 +141,13 @@ function getHackedSpec({ view, spec, width = 600, height = 600 }) {
     const xStart = colMap.get(col) || 0;
     const yStart = rowMap.get(row) || 0;
 
+    const xField = spec.meta.parse === "jitter" ? "x" : CONF.X_FIELD;
+    const yField = spec.meta.parse === "jitter" ? "y" : CONF.Y_FIELD;
+
     values.push({
       ...d,
-      x: xStart + scaleX(d.x),
-      y: (yStart + scaleY(d.y)),
+      [CONF.X_FIELD]: xStart  + scaleX(d[xField]),
+      [CONF.Y_FIELD]: (yStart + scaleY(d[yField])),
     });
   });
 
@@ -170,11 +160,6 @@ function getHackedSpec({ view, spec, width = 600, height = 600 }) {
   return newSpec;
 }
 
-/**
- * 
- * @param {Object} spec vega-lite spec
- * @returns a promise of vegaEmbed
- */
 function hackFacet(spec) {
   const div = document.createElement("div");
 


### PR DESCRIPTION
Fixes the bug in #66, where a datamation didn't work if the data contained variables named x or y, because those were used internally to calculate coordinates. We're using e.g. `datamations_x` and `datamations_y` internally now, but on the JS and R side both have a config file that controls this so can easily change if need be! Closes #66.