### PR TITLE
Added functionality for the tally verb

### DIFF
--- a/R/datamation_sanddance.R
+++ b/R/datamation_sanddance.R
@@ -36,7 +36,7 @@ datamation_sanddance <- function(pipeline, envir = rlang::global_env(), pretty =
   }
 
   # Specify which functions are supported, for parsing functions out and for erroring if any are not in this list
-  supported_tidy_functions <- c("group_by", "summarize", "filter", "count")
+  supported_tidy_functions <- c("group_by", "summarize", "filter", "count", "tally")
 
   # Convert pipeline into list
   full_fittings <- pipeline %>%
@@ -158,7 +158,8 @@ datamation_sanddance <- function(pipeline, envir = rlang::global_env(), pretty =
       group_by = prep_specs_group_by,
       summarize = prep_specs_summarize,
       filter = prep_specs_filter,
-      count = prep_specs_count
+      count = prep_specs_count,
+      tally = prep_specs_tally
     )
 
     # Call that function with the data and mapping

--- a/R/prep_specs_tally.R
+++ b/R/prep_specs_tally.R
@@ -1,4 +1,4 @@
-#' Generate specs of data for count step of datamation
+#' Generate specs of data for tally step of datamation
 #'
 #' @param .data Input data
 #' @param mapping A list that describes mapping for the datamations, including x and y variables, summary variable and operation, variables used in facets and in colors, etc. Generated in \code{datamation_sanddance} using \code{generate_mapping}.
@@ -47,5 +47,5 @@ prep_specs_tally <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, heigh
   names(res) <- NULL
 
   res
-  
+
 }

--- a/R/prep_specs_tally.R
+++ b/R/prep_specs_tally.R
@@ -7,6 +7,45 @@
 #' @noRd
 prep_specs_tally <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, height = 300, width = 300) {
 
-#TODO, ADD FUNCTIONALITY FOR TALLY
+  # Treat tally as summarize(n = n()) with optional group mappings
+  # Call prep_specs_group_by and prep_specs_summarize
 
+  res <- list()
+
+  # Group by ----
+
+  res[["group_by"]] <- prep_specs_group_by(.data, mapping, toJSON = toJSON, pretty = pretty, height = height, width = width)
+
+  # Summarize ----
+
+  # Fake mapping by adding summary_function and summary_name
+
+  mapping$summary_function <- mapping$summary_name <- "n"
+
+  # Fake "previous frame" (group_by) data
+
+  group_vars <- mapping$groups %>%
+    as.list() %>%
+    purrr::map(rlang::parse_expr)
+
+  .data <- .data %>%
+    dplyr::group_by(!!!group_vars)
+
+  res[["summarize"]] <- prep_specs_summarize(.data, mapping, toJSON = toJSON, pretty = pretty, height = height, width = width)
+
+  # Add meta field for "tally" custom animation
+  res[["summarize"]][[1]][["meta"]][["custom_animation"]] <- "tally"
+
+  # Update title of spec
+  title <- ifelse(length(group_vars) == 0, "Plot tally", "Plot tally of each group")
+  res[["summarize"]][[1]][["meta"]][["description"]] <- title
+
+  # Unlist and return
+  res <- res %>%
+    unlist(recursive = FALSE)
+
+  names(res) <- NULL
+
+  res
+  
 }

--- a/R/prep_specs_tally.R
+++ b/R/prep_specs_tally.R
@@ -1,0 +1,12 @@
+#' Generate specs of data for count step of datamation
+#'
+#' @param .data Input data
+#' @param mapping A list that describes mapping for the datamations, including x and y variables, summary variable and operation, variables used in facets and in colors, etc. Generated in \code{datamation_sanddance} using \code{generate_mapping}.
+#' @inheritParams datamation_sanddance
+#' @inheritParams prep_specs_data
+#' @noRd
+prep_specs_tally <- function(.data, mapping, toJSON = TRUE, pretty = TRUE, height = 300, width = 300) {
+
+#TODO, ADD FUNCTIONALITY FOR TALLY
+
+}


### PR DESCRIPTION
The commits add support for the tally verb by doing the following:

- Creating a function to prep specs for the tally verb, mimicking the count verb, by allowing calculation of totals with or without group mappings
- Adding support to the the `datamation_sanddance()` function to allow the passing of of tally() in a sanddance string, e.g.: "small_salary %>% group_by(Degree) %>% tally()" %>% datamation_sanddance()
